### PR TITLE
[W02] Logging Testes now also pass when logging the last step

### DIFF
--- a/w02/test/gad/logging/TestResultImplementation.java
+++ b/w02/test/gad/logging/TestResultImplementation.java
@@ -2,18 +2,28 @@ package gad.logging;
 
 import gad.binarysearch.Result;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestResultImplementation implements Result {
-    private int[] steps;
+
+    private final int[] steps;
     private int index;
 
+    public TestResultImplementation(int[][] possibleSolutions) {
+        this(Arrays.stream(possibleSolutions)
+                .mapToInt(s -> s.length)
+                .max().orElse(0));
+    }
     public TestResultImplementation(int expectedSize) {
         steps = new int[expectedSize];
     }
 
     @Override
     public void addStep(int step) {
+        System.out.println("added step to index " + step);
         if (index < steps.length) {
             steps[index] = step;
         }
@@ -25,4 +35,34 @@ public class TestResultImplementation implements Result {
 
         assertArrayEquals(solution, steps, "Logged wrong path");
     }
+
+    public void testLogging(int[][] possibleSolutions) {
+        testLogging(possibleSolutions, "");
+    }
+    public void testLogging(int[][] possibleSolutions, String messagePrefix) {
+        assertTrue(Arrays.stream(possibleSolutions).anyMatch(
+                        solution -> index == solution.length && testArrayEquals(solution, steps)
+                ),
+                messagePrefix + "steps did not match any valid solution (possibilities are: " +
+                        Arrays.stream(possibleSolutions)
+                                .map(Arrays::toString)
+                                .collect(Collectors.joining(" or ")) +
+                        ")");
+    }
+
+    /**
+     * assumes arrays have same length
+     * @param a first array
+     * @param b second array
+     * @return whether array a and b are equal
+     */
+    private boolean testArrayEquals(int[] a, int[] b) {
+        for (int i = 0; i < a.length; i++) {
+            if(a[i] != b[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/w02/test/gad/logging/loggingTest.java
+++ b/w02/test/gad/logging/loggingTest.java
@@ -13,111 +13,111 @@ public class loggingTest {
         // ---- SimpleSearch ---- //
         private static Stream<Arguments> testLoggingSimpleSearch() {
                 return Stream.of(
-                                // normal
-                                Arguments.of(new int[] { 1, 2, 3, 4 }, 2, new int[] { 1 }),
-                                Arguments.of(new int[] { 6, 23, 45, 67, 89, 90, 100 }, 90, new int[] { 3, 5 }),
-                                // values not in array
-                                Arguments.of(new int[] { 1, 2, 3, 4 }, 5, new int[] { 1, 2 }),
-                                Arguments.of(new int[] { 1, 2 }, 0, new int[] { 0 }),
-                                // duplicates in array
-                                Arguments.of(new int[] { 1, 2, 2, 2, 6, 7, 8, 9, 10 }, 2, new int[] { 4, 1 }),
-                                Arguments.of(new int[] { 1, 2, 2, 2, 6, 7, 8, 9, 10 }, 6, new int[] { 4 }));
+                        // normal
+                        Arguments.of(new int[]{1, 2, 3, 4}, 2, new int[][]{{1}}),
+                        Arguments.of(new int[]{6, 23, 45, 67, 89, 90, 100}, 90, new int[][]{{3, 5}}),
+                        // values not in array
+                        Arguments.of(new int[]{1, 2, 3, 4}, 5, new int[][]{{1, 2}, {1, 2, 3}}),
+                        Arguments.of(new int[]{1, 2}, 0, new int[][]{{0}}),
+                        // duplicates in array
+                        Arguments.of(new int[]{1, 2, 2, 2, 6, 7, 8, 9, 10}, 2, new int[][]{{4, 1}}),
+                        Arguments.of(new int[]{1, 2, 2, 2, 6, 7, 8, 9, 10}, 6, new int[][]{{4}}));
         }
 
         @ParameterizedTest
         @MethodSource
-        public void testLoggingSimpleSearch(int[] sortedData, int value, int[] expect) {
-                TestResultImplementation result = new TestResultImplementation(expect.length);
+        public void testLoggingSimpleSearch(int[] sortedData, int value, int[][] possibleSolutions) {
+                TestResultImplementation result = new TestResultImplementation(possibleSolutions);
                 BinSea.search(sortedData, value, result);
-                result.testLogging(expect);
+                result.testLogging(possibleSolutions);
         }
 
         // ---- BoundSearch ---- //
         private static Stream<Arguments> testLoggingBoundSearch() {
                 return Stream.of(
-                                // normal
-                                Arguments.of(new int[] { 1, 2, 3, 4 }, 1, true, new int[] { 1 }),
-                                Arguments.of(new int[] { 1, 2, 3, 4, 5, 6, 7, 8 }, 2, false, new int[] { 3, 1 }),
-                                // values not in array
-                                Arguments.of(new int[] { 1, 2, 2, 2, 6, 7, 8, 9, 10 }, -1, true, new int[] { 4, 1 }),
-                                Arguments.of(new int[] { 1, 2, 2, 4, 4, 4, 4, 8, 8, 27, 89 }, 3, false,
-                                                new int[] { 5, 2, 3 }),
-                                // duplicates in array
-                                Arguments.of(new int[] { 1, 2, 2, 4, 4, 4, 4, 8, 8, 27, 89 }, 4, true, new int[] { 5 }),
-                                Arguments.of(new int[] { 1, 2, 2, 4, 4, 4, 4, 8, 8, 27, 89 }, 4, false,
-                                                new int[] { 5 }),
-                                // random values
-                                Arguments.of(new int[] { 1, 4, 4, 4, 5, 5, 5, 5, 8, 10, 23 }, 6, false,
-                                                new int[] { 5, 8, 6 }),
-                                Arguments.of(new int[] { 1, 4, 4, 4, 5, 5, 5, 5, 8 }, 9, true, new int[] { 4, 6, 7 }),
-                                Arguments.of(new int[] { 1, 2, 2, 4, 4, 4, 4, 8, 8, 27, 89 }, 25, true,
-                                                new int[] { 5, 8, 9 }));
+                        // normal
+                        Arguments.of(new int[]{1, 2, 3, 4}, 1, true, new int[][]{{1}, {1, 0}}),
+                        Arguments.of(new int[]{1, 2, 3, 4, 5, 6, 7, 8}, 2, false, new int[][]{{3, 1}}),
+                        // values not in array
+                        Arguments.of(new int[]{1, 2, 2, 2, 6, 7, 8, 9, 10}, -1, true, new int[][]{{4, 1}, {4, 1, 0}}),
+                        Arguments.of(new int[]{1, 2, 2, 4, 4, 4, 4, 8, 8, 27, 89}, 3, false,
+                                new int[][]{{5, 2, 3}}),
+                        // duplicates in array
+                        Arguments.of(new int[]{1, 2, 2, 4, 4, 4, 4, 8, 8, 27, 89}, 4, true, new int[][]{{5}}),
+                        Arguments.of(new int[]{1, 2, 2, 4, 4, 4, 4, 8, 8, 27, 89}, 4, false,
+                                new int[][]{{5}}),
+                        // random values
+                        Arguments.of(new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8, 10, 23}, 6, false,
+                                new int[][]{{5, 8, 6}, {5, 8, 6, 7}}),
+                        Arguments.of(new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8}, 9, true, new int[][]{{4, 6, 7}, {4, 6, 7, 8}}),
+                        Arguments.of(new int[]{1, 2, 2, 4, 4, 4, 4, 8, 8, 27, 89}, 25, true,
+                                new int[][]{{5, 8, 9}}));
         }
 
         @ParameterizedTest
         @MethodSource
-        public void testLoggingBoundSearch(int[] sortedData, int value, boolean lowerBound, int[] expect) {
-                TestResultImplementation result = new TestResultImplementation(expect.length);
+        public void testLoggingBoundSearch(int[] sortedData, int value, boolean lowerBound, int[][] possibleSolutions) {
+                TestResultImplementation result = new TestResultImplementation(possibleSolutions);
                 BinSea.search(sortedData, value, lowerBound, result);
-                result.testLogging(expect);
+                result.testLogging(possibleSolutions);
         }
 
         // ---- IntervalSearch ---- //
         private static Stream<Arguments> testLoggingIntervalSearch() {
                 return Stream.of(
-                                // random
-                                Arguments.of(
-                                                new int[] { 1, 4, 4, 4, 5, 5, 5, 5, 8 },
-                                                Interval.NonEmptyInterval.fromArrayIndices(1, 4),
-                                                new int[] { 4, 1 },
-                                                new int[] { 4, 1 }),
-                                Arguments.of(
-                                                new int[] { 1, 4, 4, 4, 5, 5, 5, 5, 8 },
-                                                Interval.NonEmptyInterval.fromArrayIndices(2, 5),
-                                                new int[] { 4, 1 },
-                                                new int[] { 4 }),
-                                Arguments.of(
-                                                new int[] { 1, 4, 4, 4, 5, 5, 5, 5, 8, 10, 23 },
-                                                Interval.NonEmptyInterval.fromArrayIndices(3, 9),
-                                                new int[] { 5, 2, 0 },
-                                                new int[] { 5, 8, 9 }),
-                                Arguments.of(
-                                                new int[] { 1, 4, 4, 4, 5, 5, 5, 5, 8, 10, 23 },
-                                                Interval.NonEmptyInterval.fromArrayIndices(8, 8),
-                                                new int[] { 5, 8 },
-                                                new int[] { 5, 8 }),
-                                // empty
-                                Arguments.of(
-                                                new int[] { 1, 4, 4, 4, 5, 5, 5, 5, 8 },
-                                                Interval.NonEmptyInterval.fromArrayIndices(6, 7),
-                                                new int[] { 4, 6, 7 },
-                                                new int[] { 4, 6, 7 }),
-                                Arguments.of(
-                                                new int[] { 1, 4, 4, 4, 5, 5, 5, 5, 8, 2325 },
-                                                Interval.NonEmptyInterval.fromArrayIndices(235, 2311),
-                                                new int[] { 4, 7, 8 },
-                                                new int[] { 4, 7, 8 }),
-                                // only lower logging
-                                Arguments.of(
-                                                new int[] { 1, 2, 3 },
-                                                Interval.NonEmptyInterval.fromArrayIndices(4, 5),
-                                                new int[] { 1 },
-                                                new int[] {}),
-                                Arguments.of(
-                                                new int[] { 1, 4, 4, 4, 5, 5, 5, 5, 8 },
-                                                Interval.NonEmptyInterval.fromArrayIndices(10, 16),
-                                                new int[] { 4, 6, 7 },
-                                                new int[] {}));
+                        // random
+                        Arguments.of(
+                                new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8},
+                                Interval.NonEmptyInterval.fromArrayIndices(1, 4),
+                                new int[][]{{4, 1}, {4, 1, 0}},
+                                new int[][]{{4, 1}}),
+                        Arguments.of(
+                                new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8},
+                                Interval.NonEmptyInterval.fromArrayIndices(2, 5),
+                                new int[][]{{4, 1}, {4, 1, 0}},
+                                new int[][]{{4}}),
+                        Arguments.of(
+                                new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8, 10, 23},
+                                Interval.NonEmptyInterval.fromArrayIndices(3, 9),
+                                new int[][]{{5, 2, 0}, {5, 2, 0, 1}},
+                                new int[][]{{5, 8, 9}}),
+                        Arguments.of(
+                                new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8, 10, 23},
+                                Interval.NonEmptyInterval.fromArrayIndices(8, 8),
+                                new int[][]{{5, 8}},
+                                new int[][]{{5, 8}}),
+                        // empty
+                        Arguments.of(
+                                new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8},
+                                Interval.NonEmptyInterval.fromArrayIndices(6, 7),
+                                new int[][]{{4, 6, 7}, {4, 6, 7, 8}},
+                                new int[][]{{4, 6, 7}, {4, 6, 7, 8}}),
+                        Arguments.of(
+                                new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8, 2325},
+                                Interval.NonEmptyInterval.fromArrayIndices(235, 2311),
+                                new int[][]{{4, 7, 8}, {4, 7, 8, 9}},
+                                new int[][]{{4, 7, 8}, {4, 7, 8, 9}}),
+                        // only lower logging
+                        Arguments.of(
+                                new int[]{1, 2, 3},
+                                Interval.NonEmptyInterval.fromArrayIndices(4, 5),
+                                new int[][]{{1}, {1, 2}},
+                                new int[][]{{}}),
+                        Arguments.of(
+                                new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8},
+                                Interval.NonEmptyInterval.fromArrayIndices(10, 16),
+                                new int[][]{{4, 6, 7}, {4, 6, 7, 8}},
+                                new int[][]{{}}));
         }
 
         @ParameterizedTest
         @MethodSource
-        public void testLoggingIntervalSearch(int[] sortedData, Interval.NonEmptyInterval interval, int[] expectLower,
-                        int[] expectHigher) {
-                TestResultImplementation resultLower = new TestResultImplementation(expectLower.length);
-                TestResultImplementation resultHigher = new TestResultImplementation(expectHigher.length);
+        public void testLoggingIntervalSearch(int[] sortedData, Interval.NonEmptyInterval interval,
+                                              int[][] expectLowerPossibilities, int[][] expectHigherPossibilities) {
+                TestResultImplementation resultLower = new TestResultImplementation(expectLowerPossibilities);
+                TestResultImplementation resultHigher = new TestResultImplementation(expectHigherPossibilities);
                 BinSea.search(sortedData, interval, resultLower, resultHigher);
-                resultLower.testLogging(expectLower);
-                resultHigher.testLogging(expectHigher);
+                resultLower.testLogging(expectLowerPossibilities, "lower ");
+                resultHigher.testLogging(expectHigherPossibilities, "higher ");
         }
 }


### PR DESCRIPTION
As described here https://github.com/nilsreichardt/gad24-tests/issues/4#issuecomment-2083655664 the logging test currently does not allow logging the last step when from and to index are equal, but this is considered passing by the Artemis Tests.
This PR fixes this by sometimes having two options for valid steps. The same system could also be used to allow steps taken when ceiling the middle index instead of flooring.

Fixes #4