### PR TITLE
W04: fix expected return order of indices for `getMedianPivot*` and remove incorrect/duplicate test cases

### DIFF
--- a/w04/test/gad/simplesort/DoubleDistributedMedianPivotTest.java
+++ b/w04/test/gad/simplesort/DoubleDistributedMedianPivotTest.java
@@ -46,14 +46,14 @@ public class DoubleDistributedMedianPivotTest {
                 Arguments.of(
                         new int[]{30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
                                 15, 12, 9, 6, 3, 0},
-                        new int[]{2, 6},
+                        new int[]{6, 2},
                         5,
                         0,
                         11),
                 Arguments.of(
                         new int[]{30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
                                 15, 12, 9, 6, 3, 0},
-                        new int[]{14, 18},
+                        new int[]{18, 14},
                         5,
                         12,
                         21));

--- a/w04/test/gad/simplesort/DoubleMedianPivotTest.java
+++ b/w04/test/gad/simplesort/DoubleMedianPivotTest.java
@@ -42,18 +42,6 @@ public class DoubleMedianPivotTest {
                         new int[] { 1, 2 },
                         5,
                         1,
-                        4),
-                Arguments.of(
-                        new int[] { 4, 9, 1, 10, 2 },
-                        new int[] { 1, 4 },
-                        5,
-                        0,
-                        4),
-                Arguments.of(
-                        new int[] { 4, 9, 1, 10, 2 },
-                        new int[] { 1, 4 },
-                        5,
-                        0,
                         4));
     }
 

--- a/w04/test/gad/simplesort/DoubleMedianPivotTest.java
+++ b/w04/test/gad/simplesort/DoubleMedianPivotTest.java
@@ -33,7 +33,7 @@ public class DoubleMedianPivotTest {
         return Stream.of(
                 Arguments.of(
                         new int[] { 4, 9, 1, 10, 2 },
-                        new int[] { 1, 4 },
+                        new int[] { 4, 1 },
                         5,
                         0,
                         4),

--- a/w04/test/gad/simplesort/DoubleMedianPivotTest.java
+++ b/w04/test/gad/simplesort/DoubleMedianPivotTest.java
@@ -36,12 +36,6 @@ public class DoubleMedianPivotTest {
                         new int[] { 4, 1 },
                         5,
                         0,
-                        4),
-                Arguments.of(
-                        new int[] { 4, 9, 1, 10, 2, 5, 99, 23, 3, 35, 6 },
-                        new int[] { 1, 2 },
-                        5,
-                        1,
                         4));
     }
 


### PR DESCRIPTION
> Der zuerst zurückgegebene Index soll dabei der Index des kleineren Pivots sein.

This applies to both the `Front` and the `Distributed` variant.

Explanation for the removal of the incorrect test case:
We cannot split < 5 elements into 3 equally sized intervals so there is no fixed output we can test against. Any other test case would probably violate the test constraints set by the ÜL.